### PR TITLE
Fixing map zoom

### DIFF
--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -77,7 +77,7 @@ const map = props => {
     <Map
       bounds={bounds}
       maxBounds={brazilBoundingBox}
-      maxZoom={18}
+      maxZoom={15}
       style={{ height: '50%' }}
       zoomControl={false}
     >


### PR DESCRIPTION
Prevents that user can zoom to a level where there's no tiles to load